### PR TITLE
Make RetailInvestor type stable

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -28,9 +28,9 @@ struct MarketIndex <: Asset
 end
 
 struct RetailInvestor <: Investor
-    assets::Array{Float64} # N possible stakes in M funds and (1) cash
-    horizon::Array{Int64} # Positive integer, draw from range, can use rand(S)
-    threshold::Array{Float64} # ~N(0, 5)
+    assets::Matrix{Float64} # N possible stakes in M funds and (1) cash
+    horizon::Vector{Int64} # Positive integer, draw from range, can use rand(S)
+    threshold::Vector{Float64} # ~N(0, 5)
 end
 
 struct EquityFund <: AssetManager


### PR DESCRIPTION
I don't know if this change is correct, I just made a change to make the tests pass.

As it is now, this type (and all other types in the same file) is not efficient, as the fields don't have concrete types.  `Vector{Float64}` (`== Array{Float64,1}`) and `Matrix{Float64}` (`== Array{Float64,2}`) are instead concrete:
```julia
julia> Array{Float64}
Array{Float64,N} where N

julia> isconcretetype(Array{Float64})
false

julia> isconcretetype(Matrix{Float64})
true

julia> isconcretetype(Vector{Float64})
true
```

### Benchmarks

Before this PR:
```julia
julia> @btime Func.perfreview(4, $reviewers, $investors, $(funds.value))
  1.911 μs (20 allocations: 5.03 KiB)
1×2 Array{Int64,2}:
 3  3
```

After this PR:
```julia
julia> @btime Func.perfreview(4, $reviewers, $investors, $(funds.value))
  576.371 ns (8 allocations: 4.80 KiB)
1×2 Array{Int64,2}:
 3  3
```